### PR TITLE
Fix grammar: missing article in notion_cli golden README

### DIFF
--- a/real_replica_bench/mock_services/notion_cli/golden/README.md
+++ b/real_replica_bench/mock_services/notion_cli/golden/README.md
@@ -40,6 +40,6 @@ ntn workers list > noauth-workers.stdout 2>noauth-workers.stderr; echo $? > noau
 The mock uses Commander.js (Node), not Rust/clap. Help format and error
 messages will differ structurally (Commander prints `Usage: ntn-mock ...`
 vs clap's `Usage: ntn ...`). The `smoke_test.sh` golden section tests
-**version output** and **exit codes** for exact match, but flags help-text
+**version output** and **exit codes** for an exact match, but flags help-text
 comparison as known divergences (format cannot be byte-identical between
 Commander.js and clap).


### PR DESCRIPTION
## Summary

This PR fixes a grammar issue in `real_replica_bench/mock_services/notion_cli/golden/README.md` (line 43).

## Problem

Missing article 'an' before 'exact match'. The singular noun phrase 'exact match' requires an article.

The problematic text:

```
tests **version output** and **exit codes** for exact match
```

## Fix

Replaced with:

```
tests **version output** and **exit codes** for an exact match
```

## Type of Change

- [x] Documentation fix (grammar, spelling, logical error)
- [ ] Code change
- [ ] Breaking change

## Checklist

- [x] Documentation files only
- [x] No code changes
- [x] Fix verified against original text