### PR TITLE
Fix grammar: missing article in google_workspace_cli README

### DIFF
--- a/real_replica_bench/mock_services/google_workspace_cli/README.md
+++ b/real_replica_bench/mock_services/google_workspace_cli/README.md
@@ -5,7 +5,7 @@ aligned 1:1 with the tool surface published by the
 [`gemini-cli-extensions/workspace`](https://github.com/gemini-cli-extensions/workspace)
 MCP server (referenced from [`google/mcp`](https://github.com/google/mcp)).
 
-Agent interacts through the `gws` CLI; a separate HTTP server provides
+The agent interacts through the `gws` CLI; a separate HTTP server provides
 verifier-only state inspection endpoints (protected by token).
 
 ```


### PR DESCRIPTION
## Summary

This PR fixes a grammar issue in `real_replica_bench/mock_services/google_workspace_cli/README.md` (line 8).

## Problem

Missing article 'The' before 'Agent' at the start of a prose sentence. The project's other documentation consistently uses articles before 'agent' (e.g., CONTRIBUTING.md: 'an agent that never loads the page').

The problematic text:

```
Agent interacts through the `gws` CLI; a separate HTTP server provides
```

## Fix

Replaced with:

```
The agent interacts through the `gws` CLI; a separate HTTP server provides
```

## Type of Change

- [x] Documentation fix (grammar, spelling, logical error)
- [ ] Code change
- [ ] Breaking change

## Checklist

- [x] Documentation files only
- [x] No code changes
- [x] Fix verified against original text