### PR TITLE
Fix grammar: missing article in stripe_cli help text

### DIFF
--- a/real_replica_bench/mock_services/stripe_cli/lib/help_text/top.txt
+++ b/real_replica_bench/mock_services/stripe_cli/lib/help_text/top.txt
@@ -13,7 +13,7 @@ Usage:
   stripe [command]
 
 [Agent guidance]
-  Visit https://docs.stripe.com/llms.txt?utm_source=cli for latest guidance on how to integrate correctly.
+  Visit https://docs.stripe.com/llms.txt?utm_source=cli for the latest guidance on how to integrate correctly.
   Run `npx skills add --all stripe/ai` to add all Stripe AI skills to your agent.
   Additional commands (apps, docs, generate, projects) are available as installable plugins — run the command directly to be prompted, or use `stripe plugin install <name>`.
   Use --api-key to pass your key non-interactively (or set STRIPE_API_KEY).


### PR DESCRIPTION
## Summary

This PR fixes a grammar issue in `real_replica_bench/mock_services/stripe_cli/lib/help_text/top.txt` (line 16).

## Problem

Missing article 'the' before the superlative 'latest'. Superlative adjectives require a definite article.

The problematic text:

```
Visit https://docs.stripe.com/llms.txt?utm_source=cli for latest guidance on how to integrate correctly.
```

## Fix

Replaced with:

```
Visit https://docs.stripe.com/llms.txt?utm_source=cli for the latest guidance on how to integrate correctly.
```

## Type of Change

- [x] Documentation fix (grammar, spelling, logical error)
- [ ] Code change
- [ ] Breaking change

## Checklist

- [x] Documentation files only
- [x] No code changes
- [x] Fix verified against original text